### PR TITLE
Fuji token list

### DIFF
--- a/fuji.tokenlist.json
+++ b/fuji.tokenlist.json
@@ -1,0 +1,49 @@
+{
+    "name": "AVAX Fuji Tokens",
+    "logoURI": "https://raw.githubusercontent.com/ava-labs/bridge-tokens/main/avalanche-tokens/0x60781C2586D68229fde47564546784ab3fACA982/logo.png",
+    "keywords": [
+        "avalanche",
+        "fuji"
+    ],
+    "version": {
+        "major": 1,
+        "minor": 0,
+        "patch": 0
+    },
+    "timestamp": "2021-04-04T22:00:00+00:00",
+    "tokens": [
+        {
+            "address": "0x83080D4b5fC60e22dFFA8d14AD3BB41Dde48F199",
+            "chainId": 43113,
+            "name": "Pangolin",
+            "symbol": "PNG",
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/ava-labs/bridge-tokens/main/avalanche-tokens/0x60781C2586D68229fde47564546784ab3fACA982/logo.png"
+        },
+        {
+            "chainId": 43113,
+            "address": "0x34B6C87bb59Eb37EFe35C8d594a234Cd8C654D50",
+            "decimals": 18,
+            "name": "Dai Stablecoin",
+            "symbol": "DAI",
+            "logoURI": "https://raw.githubusercontent.com/ava-labs/bridge-tokens/main/avalanche-tokens/0xbA7dEebBFC5fA1100Fb055a87773e1E99Cd3507a/logo.png"
+        },
+        {
+            "chainId": 43113,
+            "address": "0xf4E0A9224e8827dE91050b528F34e2F99C82Fbf6",
+            "decimals": 18,
+            "name": "Uniswap",
+            "symbol": "UNI",
+            "logoURI": "https://raw.githubusercontent.com/ava-labs/bridge-tokens/main/avalanche-tokens/0xf39f9671906d8630812f9d9863bBEf5D523c84Ab/logo.png"
+        },
+        {
+            "chainId": 43113,
+            "address": "0x72C14f7fB8B14040dA6E5b1B9D1B9438ebD85F58",
+            "decimals": 18,
+            "name": "SushiToken",
+            "symbol": "SUSHI",
+            "logoURI": "https://raw.githubusercontent.com/ava-labs/bridge-tokens/main/avalanche-tokens/0x39cf1BD5f15fb22eC3D9Ff86b0727aFc203427cc/logo.png"
+        }
+
+    ]
+}

--- a/fuji.tokenlist.json
+++ b/fuji.tokenlist.json
@@ -13,6 +13,14 @@
     "timestamp": "2021-04-04T22:00:00+00:00",
     "tokens": [
         {
+            "address": "0xd00ae08403B9bbb9124bB305C09058E32C39A48c",
+            "chainId": 43113,
+            "name": "Wrapped AVAX",
+            "symbol": "WAVAX",
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/ava-labs/bridge-tokens/main/avalanche-tokens/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7/logo.png"
+        },
+        {
             "address": "0x83080D4b5fC60e22dFFA8d14AD3BB41Dde48F199",
             "chainId": 43113,
             "name": "Pangolin",
@@ -46,7 +54,7 @@
         },
         {
             "chainId": 43113,
-            "address": "0x47523b7C935671d6e4AC0CB8f9F6a3Fa60Fe298b",
+            "address": "0x2F0708E5FB96fd1E9F21eAbAd06EE5F337586A02",
             "decimals": 18,
             "name": "ChainLink Token",
             "symbol": "LINK",

--- a/fuji.tokenlist.json
+++ b/fuji.tokenlist.json
@@ -8,7 +8,7 @@
     "version": {
         "major": 1,
         "minor": 0,
-        "patch": 0
+        "patch": 1
     },
     "timestamp": "2021-04-04T22:00:00+00:00",
     "tokens": [
@@ -43,7 +43,14 @@
             "name": "SushiToken",
             "symbol": "SUSHI",
             "logoURI": "https://raw.githubusercontent.com/ava-labs/bridge-tokens/main/avalanche-tokens/0x39cf1BD5f15fb22eC3D9Ff86b0727aFc203427cc/logo.png"
+        },
+        {
+            "chainId": 43113,
+            "address": "0x47523b7C935671d6e4AC0CB8f9F6a3Fa60Fe298b",
+            "decimals": 18,
+            "name": "ChainLink Token",
+            "symbol": "LINK",
+            "logoURI": "https://raw.githubusercontent.com/ava-labs/bridge-tokens/main/avalanche-tokens/0xB3fe5374F67D7a22886A0eE082b2E2f9d2651651/logo.png"
         }
-
     ]
 }


### PR DESCRIPTION
I've added a Fuji token list which will allow us to run test simulations on Fuji.

This will help us when we're testing contracts that utilise other tokens, for example ChainLink.